### PR TITLE
unibi_from_term: make $TERMINFO behavior compatible to curses

### DIFF
--- a/doc/unibi_from_term.pod
+++ b/doc/unibi_from_term.pod
@@ -21,7 +21,8 @@ It looks in the following places:
 =item 1.
 
 If the environment variable C<TERMINFO> is set, it is interpreted as the name
-of the directory to search. No other directory is used.
+of the directory to search for local terminal definitions before checking in
+the standard place.
 
 =item 2.
 

--- a/uniutil.c
+++ b/uniutil.c
@@ -183,7 +183,10 @@ unibi_term *unibi_from_term(const char *term) {
     }
 
     if ((env = getenv("TERMINFO"))) {
-        return from_dir(env, NULL, NULL, term);
+        ut = from_dir(env, NULL, NULL, term);
+        if (ut) {
+            return ut;
+        }
     }
 
     if ((env = getenv("HOME"))) {


### PR DESCRIPTION
kitty e.g. sets `$TERMINFO` (at least when using the development version),
but it only contains its own entry for xterm-kitty.

When you start tmux then from there, tmux uses this `$TERMINFO` variable,
and then Neovim would fail to parse `TERM=screen` properly (via
`unibi_from_term`) then.

Fixes https://github.com/mauke/unibilium/issues/36.