### PR TITLE
unibi_from_mem: fix [clang-analyzer-deadcode.DeadStores]

### DIFF
--- a/unibilium.c
+++ b/unibilium.c
@@ -432,9 +432,6 @@ unibi_term *unibi_from_mem(const char *p, size_t n) {
                 if (exttablsz) {
                     memcpy(t->ext_alloc, p, exttablsz);
                     t->ext_alloc[exttablsz - 1] = '\0';
-
-                    p += exttablsz;
-                    n -= exttablsz;
                 }
             }
         }


### PR DESCRIPTION
Fixes:

> Value stored to 'p' is never read [clang-analyzer-deadcode.DeadStores]
> Value stored to 'n' is never read [clang-analyzer-deadcode.DeadStores]