### PR TITLE
release: 2.1.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,14 @@
+2.1.0   2020-02-11
+        - Makefile: use "-f" with prove always (to show failed tests) (#13)
+        - Stop searching in further dirs on errors except ENOENT #12
+        - Makefile: do not rebuild t/static_%.c with updated gen-static-test
+        - Add CMakeLists.txt and support for MSVC (#3)
+        - Relax checks for extended capability to support new format (#5)
+        - Makefile: use -Og with DEBUG=1 (#7)
+        - unibi_from_mem: fix [clang-analyzer-deadcode.DeadStores] (#8)
+        - Makefile: revisit regenerate-tests rule (#6)
+        - unibi_from_term: handle $TERMINFO as curses does #2
+
 2.0.0   2018-02-08
         - rewrite unibi_var_t internals (now the only official access is via
           the helper functions)

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ CFLAGS_DEBUG=
 PACKAGE=unibilium
 
 PKG_MAJOR=2
-PKG_MINOR=0
+PKG_MINOR=1
 PKG_REVISION=0
 
 PKG_VERSION=$(PKG_MAJOR).$(PKG_MINOR).$(PKG_REVISION)
 
 # I am implementation $LT_REVISION of binary interface $LT_CURRENT, which is
 # a superset of all interfaces back to $LT_CURRENT - $LT_AGE.
-LT_REVISION=0
+LT_REVISION=1
 LT_CURRENT=4
 LT_AGE=0
 


### PR DESCRIPTION
close https://github.com/neovim/unibilium/issues/14

libtool `-version-info` :  https://autotools.io/libtool/version.html

> The rules of thumb, when dealing with these values are:
> - Always increase the revision value.
> - Increase the current value whenever an interface has been added, removed or changed.
> - Increase the age value only if the changes made to the ABI are backward compatible.

cf. https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html

cc @jamessan @blueyed 