### PR TITLE
build: Fix undefined references with static builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ uniutil.lo: uniutil.c unibilium.h
 $(LIBRARY): $(OBJECTS)
 	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -rpath '$(LIBDIR)' -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) -o $@ $^
 
-tools/%: $(LIBRARY) tools/%.lo
+tools/%: $(LIBRARY) $(OBJECTS) tools/%.lo
 	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -o $@ $^
 
-%.t: $(LIBRARY) %.lo
+%.t: $(LIBRARY) $(OBJECTS) %.lo
 	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -o $@ $^
 
 .PHONY: build-tools


### PR DESCRIPTION
When building unibium with slibtool (https://dev.midipix.org/cross/slibtool) and the slibtool-static symlink (Static build only) it exposes several undefined references.
```
dlibtool-static --mode=link --tag=CC cc -o tools/gen-static-test libunibilium.la tools/gen-static-test.lo

dlibtool-static: link: cc .libs/libunibilium.a tools/.libs/gen-static-test.o -L.libs -o tools/.libs/gen-static-test
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: tools/.libs/gen-static-test.o: in function `main':
gen-static-test.c:(.text.startup+0x3e): undefined reference to `unibi_from_term'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x5f): undefined reference to `unibi_dump'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x2df): undefined reference to `unibi_get_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x36a): undefined reference to `unibi_get_aliases'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x51c): undefined reference to `unibi_get_bool'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x526): undefined reference to `unibi_name_bool'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x58e): undefined reference to `unibi_get_num'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x598): undefined reference to `unibi_name_num'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x6be): undefined reference to `unibi_get_str'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x6c8): undefined reference to `unibi_name_str'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x718): undefined reference to `unibi_count_ext_bool'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x777): undefined reference to `unibi_get_ext_bool'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x785): undefined reference to `unibi_get_ext_bool_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x87d): undefined reference to `unibi_count_ext_num'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x8df): undefined reference to `unibi_get_ext_num'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x8ed): undefined reference to `unibi_get_ext_num_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0x9e6): undefined reference to `unibi_count_ext_str'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0xb47): undefined reference to `unibi_get_ext_str'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0xb55): undefined reference to `unibi_get_ext_str_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0xcf5): undefined reference to `unibi_destroy'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: gen-static-test.c:(.text.startup+0xd45): undefined reference to `unibi_from_fp'
collect2: error: ld returned 1 exit status
dlibtool-static: exec error upon slbt_exec_link_create_executable(), line 1614: (see child process error messages).
dlibtool-static: < returned to > slbt_exec_link(), line 1934.
make: *** [Makefile:78: tools/gen-static-test] Error 2
rm tools/gen-static-test.lo
````
````
dlibtool-static --mode=link --tag=CC cc -o t/00_load.t libunibilium.la t/00_load.lo

dlibtool-static: link: cc .libs/libunibilium.a t/.libs/00_load.o -L.libs -o t/.libs/00_load.t
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: t/.libs/00_load.o: in function `main':
00_load.c:(.text.startup+0x26): undefined reference to `unibi_dummy'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: 00_load.c:(.text.startup+0x3d): undefined reference to `unibi_destroy'
collect2: error: ld returned 1 exit status
dlibtool-static: exec error upon slbt_exec_link_create_executable(), line 1614: (see child process error messages).
dlibtool-static: < returned to > slbt_exec_link(), line 1934.
make: *** [Makefile:81: t/00_load.t] Error 2
rm tools/unibi-put.lo tools/unibi-dump.lo t/00_load.lo tools/gen-static-test.lo
```
This can be fixed by added `$(OBJECTS)` to the failing build rules where it now builds with GNU libtool, slibtool (Both shared and static), slibtool-shared (Shared only) and slibtool-static (Static only).
