### PR TITLE
[README] use neovim issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Run
     make test
 
 to run the included test suite. If that fails, please report it at
-https://github.com/mauke/unibilium/issues.
+https://github.com/neovim/unibilium/issues.
 
 Installing
 ----------


### PR DESCRIPTION
It appears that this fork has overtaken the upstream, as reflected at Repology. In that case, the issue link ought IMHO be updated to point at this repo.