### PR TITLE
build: Add a minimal configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ tools/*
 .*.swp
 /.maint
 /tags
+
+# autoreconf
+aclocal.m4
+autom4te.cache/
+config.guess
+config.sub
+configure
+ltmain.sh
+
+# configure
+Makefile
+config.log
+config.status
+libtool

--- a/Makefile.in
+++ b/Makefile.in
@@ -2,21 +2,19 @@ ifneq ($(wildcard .maint),)
   include maint.mk
 endif
 
-ifeq ($(shell uname),Darwin)
-  LIBTOOL?=glibtool
-else
-  LIBTOOL?=libtool
-endif
+CC=@CC@
+LIBTOOL=@LIBTOOL@
 
-CFLAGS?=-O2
+CFLAGS=@CFLAGS@
+LDFLAGS=@LDFLAGS@
 
 CFLAGS_DEBUG=
 
-PACKAGE=unibilium
+PACKAGE=@PACKAGE_NAME@
 
-PKG_MAJOR=2
-PKG_MINOR=1
-PKG_REVISION=1
+PKG_MAJOR=@MAJOR@
+PKG_MINOR=@MINOR@
+PKG_REVISION=@PATCH@
 
 PKG_VERSION=$(PKG_MAJOR).$(PKG_MINOR).$(PKG_REVISION)
 
@@ -26,10 +24,15 @@ LT_REVISION=1
 LT_CURRENT=4
 LT_AGE=0
 
-PREFIX=/usr/local
-LIBDIR=$(PREFIX)/lib
-INCDIR=$(PREFIX)/include
-MANDIR=$(PREFIX)/share/man
+top_builddir=@top_builddir@
+
+prefix=@prefix@
+exec_prefix=@prefix@
+datarootdir=@datarootdir@
+
+LIBDIR=@libdir@
+INCDIR=@includedir@
+MANDIR=@mandir@
 MAN3DIR=$(MANDIR)/man3
 
 ifneq ($(OS),Windows_NT)

--- a/README.md
+++ b/README.md
@@ -23,19 +23,33 @@ Prerequisites
   running the test suite)
 - gzip (for compressing the man pages)
 
+Configure
+---------
+
+To generate the `configure` script run:
+
+    autoreconf -fi
+
+To list the `configure` options run:
+
+    ./configure --help
+
+To generate the `Makefile` run:
+
+    ./configure --prefix=...
+
 Building
 --------
 
-There is no configure step. Compile `unibilium.c`, `uninames.c`, and
-`uniutil.c` into a library.
+Compile `unibilium.c`, `uninames.c`, and `uniutil.c` into a library.
 
-The included `Makefile` does this for you:
+The generated `Makefile` does this for you:
 
-    make PREFIX=/usr/local
+    make
 
 or
 
-    make all PREFIX=/usr/local
+    make all
 
 creates the library files, generates the man pages, and compiles the test
 suite.
@@ -84,7 +98,7 @@ Installing
 
 Run
 
-    make install PREFIX=...
+    make install
 
 to install the library, header files, man pages, and pkg-config file. Take
 care to specify the same `PREFIX`, `LIBDIR`, `INCDIR`, and `MANDIR` settings
@@ -94,7 +108,7 @@ you used for building.
 
 - `DESTDIR`: Acts as an additional prefix for the final installation step. For
   example, if you do
-  `make PREFIX=/usr && make install PREFIX=/usr DESTDIR=/tmp`, then the
+  `./configure --prefix=/usr && make && make install DESTDIR=/tmp`, then the
   library will be configured for installation under `/usr`, but the actual
   files will be copied to `/tmp/usr`. Defaults to empty.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,16 @@
+m4_define([MAJOR], [2])
+m4_define([MINOR], [1])
+m4_define([PATCH], [1])
+
+AC_INIT([unibilium], [MAJOR.MINOR.PATCH])
+AC_CONFIG_FILES([Makefile])
+
+LT_INIT
+
+AC_SUBST([top_builddir], [$abs_builddir])
+
+AC_SUBST([MAJOR], [MAJOR])
+AC_SUBST([MINOR], [MINOR])
+AC_SUBST([PATCH], [PATCH])
+
+AC_OUTPUT


### PR DESCRIPTION
When building with slibtool using the rlibtool symlink the build will
fail when it fails to find the generated libtool. This is required so
rlibtool can determine if it should build shared or static libraries.

This can be fixed by adding a minimal configure.ac that can generate the
required files with autoreconf.

Gentoo Bug: https://bugs.gentoo.org/828492

The build process that works for me is:
```
autoreconf -fi
./configure
make
```