### PR TITLE
Do not stop searching on EPERM

### DIFF
--- a/uniutil.c
+++ b/uniutil.c
@@ -162,8 +162,12 @@ static unibi_term *from_dirs(const char *list, const char *term) {
         z = strchr(a, ':');
 
         ut = from_dir(a, z, NULL, term);
-        if (ut || errno != ENOENT) {
+        if (ut) {
             return ut;
+        }
+
+        if (errno != ENOENT && errno != EPERM && errno != EACCES) {
+            return NULL;
         }
 
         if (!z) {
@@ -196,8 +200,13 @@ unibi_term *unibi_from_term(const char *term) {
 
     if ((env = getenv("HOME"))) {
         ut = from_dir(env, NULL, ".terminfo", term);
-        if (ut || errno != ENOENT) {
+
+        if (ut) {
             return ut;
+        }
+
+        if (errno != ENOENT && errno != EPERM && errno != EACCES) {
+            return NULL;
         }
     }
 


### PR DESCRIPTION
Stopping on EPERM prevents nvim from finding the correct file when it is executed via sudoedit.

When running as sudoedit, the first directory of TERMINFO_DIRS is /root/.nix-profile/share/terminfo, however the process is executed by non-root user. Even though the correct file doesn't exist in that directory, we get EPERM instead of ENOENT, because /root can't be listed by non-root users by default.

This causes the search to terminate and nvim ends up with builtin_ansi &term.