### PR TITLE
build(cmake): allow user to set `TERMINFO_DIRS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,13 @@ if(NOT WIN32)
       ncursesw5-config --terminfo-dirs 2>/dev/null || \
       ncurses5-config  --terminfo-dirs 2>/dev/null || \
       echo '/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo'"
-    OUTPUT_VARIABLE TERMINFO_DIRS)
+    OUTPUT_VARIABLE TERMINFO_DIRS_DEFAULT)
   # Remove trailing newline
-  string(STRIP "${TERMINFO_DIRS}" TERMINFO_DIRS)
+  string(STRIP "${TERMINFO_DIRS_DEFAULT}" TERMINFO_DIRS_DEFAULT)
 else()
-  set(TERMINFO_DIRS "")
+  set(TERMINFO_DIRS_DEFAULT "")
 endif()
+set(TERMINFO_DIRS "${TERMINFO_DIRS_DEFAULT}" CACHE STRING "Colon-separated list of directories where unibilium should look for compiled terminfo files at runtime")
 target_compile_definitions(unibilium PUBLIC "TERMINFO_DIRS=\"${TERMINFO_DIRS}\"")
 
 include(GNUInstallDirs)


### PR DESCRIPTION
This is useful for packagers who may wish to set `TERMINFO_DIRS` to something more applicable.

This also mirrors the behaviour of the `Makefile`, which allows you to do something like `make TERMINFO_DIRS=\"foo\"` to customise the default terminfo dirs.