### PR TITLE
fix(cmake): add new required TERMINFO variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,27 @@ set_target_properties(unibilium PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/u
   VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
 
 if(NOT WIN32)
+  execute_process(COMMAND sh -c "ncursesw6-config --terminfo 2>/dev/null || \
+      ncurses6-config  --terminfo 2>/dev/null || \
+      ncursesw5-config --terminfo 2>/dev/null || \
+      ncurses5-config  --terminfo 2>/dev/null || \
+      echo '/usr/share/terminfo'"
+    OUTPUT_VARIABLE TERMINFO_DEFAULT)
   execute_process(COMMAND sh -c "ncursesw6-config --terminfo-dirs 2>/dev/null || \
       ncurses6-config  --terminfo-dirs 2>/dev/null || \
       ncursesw5-config --terminfo-dirs 2>/dev/null || \
       ncurses5-config  --terminfo-dirs 2>/dev/null || \
       echo '/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo'"
     OUTPUT_VARIABLE TERMINFO_DIRS_DEFAULT)
-  # Remove trailing newline
+  # Remove trailing newlines
+  string(STRIP "${TERMINFO_DEFAULT}" TERMINFO_DEFAULT)
   string(STRIP "${TERMINFO_DIRS_DEFAULT}" TERMINFO_DIRS_DEFAULT)
 else()
+  set(TERMINFO_DEFAULT "")
   set(TERMINFO_DIRS_DEFAULT "")
 endif()
+set(TERMINFO "${TERMINFO_DEFAULT}" CACHE STRING "Path to compiled terminfo file unibilium should use at runtime for empty entries in TERMINFO_DIRS")
+target_compile_definitions(unibilium PUBLIC "TERMINFO=\"${TERMINFO}\"")
 set(TERMINFO_DIRS "${TERMINFO_DIRS_DEFAULT}" CACHE STRING "Colon-separated list of directories where unibilium should look for compiled terminfo files at runtime")
 target_compile_definitions(unibilium PUBLIC "TERMINFO_DIRS=\"${TERMINFO_DIRS}\"")
 


### PR DESCRIPTION
Problem: #31 added a new TERMINFO variable that is checked at build
time; this was added to the Makefile but not the CMake script (which
Neovim uses).

Solution: Define TERMINFO in CMakeLists.txt as well, copying the logic
from the Makefile.
